### PR TITLE
update GetSemanticModel to use SemanticModel to get the class declara…

### DIFF
--- a/src/DebugDisplay.Generator/DebugDisplayGenerator.cs
+++ b/src/DebugDisplay.Generator/DebugDisplayGenerator.cs
@@ -31,14 +31,15 @@ public sealed class DebugDisplayGenerator : IIncrementalGenerator // preferred o
     {
         return node is ClassDeclarationSyntax { AttributeLists.Count: > 0 };
     }
-    private static ClassDeclarationSyntax? GetSemanticTarget(GeneratorSyntaxContext ctx)
+    private static ClassDeclarationSyntax? GetSemanticTarget(GeneratorSyntaxContext context)
     {
-        ClassDeclarationSyntax classDeclaration = (ClassDeclarationSyntax)ctx.Node;
+        ClassDeclarationSyntax classDeclaration = (ClassDeclarationSyntax)context.Node;
+        INamedTypeSymbol? classSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration);
+        INamedTypeSymbol? attributeSymbol = context.SemanticModel.Compilation
+            .GetTypeByMetadataName("TSMoreland.SourceGenerators.DebugDisplay.Generator.GenerateDebugDisplayAttribute");
 
-        bool hasGenerateDebugDisplayAttribute = classDeclaration.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Select(attributeSyntax => attributeSyntax.Name.ToString())
-            .Any(attributeName => attributeName is "GenerateDebugDisplay" or "GenerateDebugDisplayAttribute");
+        bool hasGenerateDebugDisplayAttribute = classSymbol is not null && classSymbol.GetAttributes()
+            .Any(symbol => symbol.AttributeClass?.Equals(attributeSymbol) is true);
 
         return hasGenerateDebugDisplayAttribute
             ? classDeclaration


### PR DESCRIPTION
…tion and from their the attribute declarations, that comopared to the attribute symbol for our generated attribute retrieved from the semanticmodel compilation allows an exact type match rather than rely on attribute name (without namespace)